### PR TITLE
vibe: Split-Transaction, exclusion tags

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,86 @@
+########################################
+# Firefly III – Auto-save configuration #
+########################################
+
+# Base URL of your Firefly III instance (without /api/v1)
+FIREFLY_URL=https://firefly.example.com
+
+# Personal Access Token (PAT) generated in Firefly III
+FIREFLY_TOKEN=PASTE_YOUR_TOKEN_HERE
+
+
+########################################
+# Accounts
+########################################
+
+# Source account (e.g. checking account)
+ACCOUNT=1
+
+# Destination account (e.g. savings account)
+DESTINATION=2
+
+
+########################################
+# Auto-save logic
+########################################
+
+# Round up expenses to this value (e.g. 5 = round to next 5 currency units)
+AMOUNT=5
+
+# How many days in the past should be processed
+# 0 = process all transactions
+DAYS=10
+
+
+########################################
+# Safety & filters
+########################################
+
+# Minimum balance of the source account AFTER the original transaction
+# If balance <= MIN_BALANCE, auto-save is skipped
+MIN_BALANCE=20
+
+# Comma-separated list of TAGS that will EXCLUDE a transaction from auto-save
+# Matching is exact and case-insensitive
+EXCLUDE_KEYWORDS=SEPA,Lastschrift
+
+
+########################################
+# Transaction filtering
+########################################
+
+# Only process transactions of this type
+# Recommended: withdrawal (expenses)
+ONLY_TYPE=withdrawal
+
+
+########################################
+# Tags on auto-save transactions
+########################################
+
+# Public tag applied to auto-save transactions
+AUTOSAVE_TAG=autosave
+
+# An additional internal tag is always applied:
+# __autosave__
+
+
+########################################
+# Transaction linking
+########################################
+
+# Default Firefly III link type:
+# "relates to" / "bezieht sich auf"
+# This link type is automatically created during installation
+LINK_TYPE_ID=1
+
+
+########################################
+# Runtime options
+########################################
+
+# true = do not create transactions, only log actions
+DRY_RUN=false
+
+# true = verbose API output
+VERBOSE=false


### PR DESCRIPTION
<!--
Thank you for submitting new code to Firefly III, or any of the related projects. Please read the following rules carefully.

- Please do not submit solutions for problems that are not already reported in an issue.
- Unfortunately, Firefly III can't be your learning experience. If you're new to all of this, please open an issue first.
- Please do not open PRs to "discuss" possible solutions or to "get feedback" on your code. I simply don't have time for that.
- Pull requests for the MAIN branch will be closed.
- DO NOT include translated strings in your PR.

If it feels necessary to open an issue first, please do so, before you open a PR.

See also: https://docs.firefly-iii.org/explanation/support/#contributing-code

-->
    
This PR fixes issue # (if relevant).

Changes in this pull request:

complete rewrite of php code with help of vibe / chatgpt
useage of .env file for parameters like token, accounts, exclusion keywords
possible to declare exclusion keywords for skipping transactions (like automatic payments through paypal / sepa)
usage of a minimum amount --> if amount of your acount is less than defined, no autosave will be created. ING use this and will deactivate the feature "Kleingeld Sparen" automatically, if you have less than 20€ in your account

auto tag is set for each autosave --> usage in rules etc. possible
-
-
-

@JC5
